### PR TITLE
Add strip param to remove Comments from binary

### DIFF
--- a/config.nims
+++ b/config.nims
@@ -14,7 +14,7 @@ else:
 ## Constants
 const
   doOptimize = true
-  stripSwitches = @["-s"]
+  stripSwitches = @["-s", "--remove-section=.comment"]
   # upxSwitches = @["--best"]     # fast
   upxSwitches = @["--ultra-brute"] # slower
   checksumsSwitches = @["--tag"]


### PR DESCRIPTION
- Add strip param to remove Comments from binary

```console
$ echo "echo 42 ## just testing strip options" > hi.nim                                                                                               

$ nim c hi.nim                                                                                                                                        

$ objdump --section=.comment --full-contents hi                                                                                                      
.comment:
 0000 4743433a 2028474e 55292038 2e322e31  GCC: (GNU) 8.2.1
 0010 20323031 38313132 37004743 433a2028   20181127.GCC: (
 0020 474e5529 20382e33 2e3000             GNU) 8.3.0.     

$ nim c -d:release --opt:size --passL:-s hi.nim                                                                                                       

$ objdump --section=.comment --full-contents hi                                                                                                       
.comment:
 0000 4743433a 2028474e 55292038 2e322e31  GCC: (GNU) 8.2.1
 0010 20323031 38313132 37004743 433a2028   20181127.GCC: (
 0020 474e5529 20382e33 2e3000             GNU) 8.3.0.     

$ strip -s hi

$ objdump --section=.comment --full-contents hi
.comment:
 0000 4743433a 2028474e 55292038 2e322e31  GCC: (GNU) 8.2.1
 0010 20323031 38313132 37004743 433a2028   20181127.GCC: (
 0020 474e5529 20382e33 2e3000             GNU) 8.3.0.

$ strip -s --remove-section=.comment hi

$ objdump --section=.comment --full-contents hi

$
```

https://linux.die.net/man/1/strip
https://lists.debian.org/debian-policy/1998/03/msg00256.html
