### PR TITLE
Add nim4pypi

### DIFF
--- a/README.org
+++ b/README.org
@@ -32,6 +32,7 @@ test                 Run tests via 'nim doc' (runnableExamples) and tests in tes
 docs                 Deploy doc html + search index to public/ directory
 runc                 Run equivalent of 'nim c -r ..'
 runcpp               Run equivalent of 'nim cpp -r ..'
+nim4pypi             Package Nim+Nimpy Python lib for Linux/Windows/Mac ready for upload to PYPI
 #+end_example
 * How to use this
 ** Use in your local projects

--- a/config.nims
+++ b/config.nims
@@ -588,5 +588,5 @@ task nim4pypi, "Package Nim+Nimpy Python lib for Linux/Windows/Mac ready for upl
     withDir("mac"):
       cpFile(nimbaseH, "nimbase.h")
     runUtil(packageName & ".zip *", zipExe, zipSwitches)
-    echo "\nApple Mac OSX: Compile manually and copy all the .c files to 'mac/' folder, see https://github.com/foxlet/macOS-Simple-KVM"
+    echo "\nApple Mac OSX: Compile manually and copy all the .c files to 'mac/' folder, see https://github.com/foxlet/macOS-Simple-KVM or https://github.com/sickcodes/Docker-OSX"
   setCommand("nop")

--- a/config.nims
+++ b/config.nims
@@ -1,6 +1,7 @@
 from macros import error
-from strutils import `%`, endsWith, strip, replace
+from strutils import `%`, endsWith, strip, replace, format
 from sequtils import filterIt, concat
+from os import getHomeDir, getTempDir
 
 const
   nimVersion = (major: NimMajor, minor: NimMinor, patch: NimPatch)
@@ -39,6 +40,56 @@ const
   checksumsSwitches = @["--tag"]
   gpgSignSwitches = @["--clear-sign", "--armor", "--detach-sign", "--digest-algo sha512"]
   gpgEncryptSwitches = @["--armor", "--symmetric", "--s2k-digest-algo sha512", "--cipher-algo AES256", "-z 9"] # 9=Max, 0=Disabled
+  zipSwitches = @["-9", "-T", "-v", "-r"]
+
+const setupCfg = """# See: https://setuptools.readthedocs.io/en/latest/setuptools.html#metadata
+[metadata]
+name             = $1
+keywords         = python3, cpython, speed, cython, c, performance, compiled, native, fast, nim
+license          = MIT
+platforms        = Linux, Darwin, Windows
+version          = 0.0.1
+license_file     = LICENSE
+long_description = file: README.md
+long_description_content_type = text/markdown
+classifiers =
+  Environment :: Other Environment
+  Intended Audience :: Other Audience
+  Operating System :: OS Independent
+  Programming Language :: Python
+
+[options]
+zip_safe = True
+include_package_data = True
+python_requires = >=3.8
+packages = find:
+
+[options.package_data]
+* = *.c, *.h
+
+[options.exclude_package_data]
+* = *.py, *.pyc, *.sh, *.nim, *.so, *.dll, *.zip, *.js, *.tests, *.tests.*, tests.*, tests
+
+[options.packages.find]
+include = *.c, *.h
+exclude = *.py, *.pyc, *.sh, *.nim, *.so, *.dll, *.zip, *.js, *.tests, *.tests.*, tests.*, tests
+"""
+
+const setupPy = """import os, sys, pathlib, setuptools
+if sys.platform.startswith("lin"):
+  folder = "lin" # OS is Linux
+elif sys.platform.startswith("win"):
+  folder = "win" # OS is Windows
+else:
+  folder = "mac" # OS is Mac (Manual compile and copy of C files required)
+sources = []
+for c_source_file in os.listdir(folder): # Walk the folder with C files.
+  if c_source_file.endswith(".c"):       # Collect all C files.
+    sources.append(str(pathlib.Path(folder) / c_source_file))
+setuptools.setup(ext_modules = [setuptools.Extension(
+  extra_compile_args = ["-flto", "-ffast-math", "-march=native", "-mtune=native", "-O3", "-fsingle-precision-constant"],
+  name = "$1", sources = sources, extra_link_args = ["-s"], include_dirs = [folder])]) """
+
 
 proc getGitRootMaybe(): string =
   ## Try to get the path to the current git root directory.
@@ -466,3 +517,58 @@ when defined(musl):
     switch("passL", "-lcrypto") # This *has* to come *after* -lssl
     switch("dynlibOverride", "libssl")
     switch("dynlibOverride", "libcrypto")
+
+task nim4pypi, "Package Nim+Nimpy Python lib for Linux/Windows/Mac ready for upload to PYPI":
+  ## nim4pypi takes 1 full path of 1 Nim+Nimpy source code file and packages it for Pythons PYPI,
+  ## creates setup.py, setup.cfg, helper scripts, ZIP Python Package, C files, H files, and more.
+  switch("verbosity", "0")
+  hint("Processing", false)
+  const gccWin32 = system.findExe("x86_64-w64-mingw32-gcc")
+  assert gccWin32.len > 0, "x86_64-w64-mingw32-gcc not found"
+  const zipExe = system.findExe("zip")
+  assert zipExe.len > 0, "zip command not found"
+  const nimbaseH = getHomeDir() / ".choosenim/toolchains/nim-" & NimVersion / "lib/nimbase.h"
+  let
+    (_, binFiles) = parseArgs()
+    sourcePath = $binFiles[0] # Just pass full path of main file of the lib, even if lib has several files
+    packageName = splitFile(sourcePath).name
+  assert sourcePath.len > 0 and packageName.len > 0, "Nim source code file not found"
+  --app:lib  # Settings for Python module compilation
+  --opt:speed
+  --cpu:amd64
+  --forceBuild
+  --define:ssl
+  --threads:on
+  --compileOnly
+  --define:danger
+  --define:release
+  --exceptions:goto
+  --gc:markAndSweep
+  --tlsEmulation:off
+  --define:noSignalHandler
+  --excessiveStackTrace:off
+  --outdir:getTempDir() # Save the *.so to /tmp, so is not on the package, we ship C
+  rmDir("dist")
+  mkDir("dist")
+  writeFile("upload2pypi.sh", "twine upload --verbose --repository-url 'https://test.pypi.org/legacy' --comment 'Powered by https://Nim-lang.org' dist/*.zip\n")
+  writeFile("package4pypi.sh", "cd dist && zip -9 -T -v -r " & packageName & ".zip *\n")
+  writeFile("install2local4testing.sh", "sudo pip --verbose install dist/*.zip --no-binary :all:\nsudo pip uninstall " & packageName)
+  withDir("dist"):
+    mkDir("lin") # C for Linux, compile for Linux, save C files to lin/*.c
+    mkDir("win") # C for Windows, compile for Windows, save C files to win/*.c
+    mkDir("mac") # C for Mac OSX, manual compile, manual copy C files to mac/*.c
+    writeFile("setup.py", setupPy.format(packageName))   # C Extension compilation with Python stdlib
+    writeFile("setup.cfg", setupCfg.format(packageName)) # Metadata
+    withDir("lin"):
+      selfExec "compileToC --nimcache:. " & sourcePath   # C for Linux
+      rmFile(packageName & ".json") # Nim compiler creates this, unneeded here
+      cpFile(nimbaseH, "nimbase.h") # H file must be with the C files
+    withDir("win"): # Repeat the same but for Windows
+      selfExec "compileToC --nimcache:. --os:windows --gcc.exe:" & gccWin32 & " --gcc.linkerexe:" & gccWin32 & " " & sourcePath
+      rmFile(packageName & ".json")
+      cpFile(nimbaseH, "nimbase.h")
+    withDir("mac"):
+      cpFile(nimbaseH, "nimbase.h")
+    runUtil(packageName & ".zip *", zipExe, zipSwitches)
+    echo "\nApple Mac OSX: Compile manually and copy all the .c files to 'mac/' folder, see https://github.com/foxlet/macOS-Simple-KVM"
+  setCommand("nop")


### PR DESCRIPTION
- Package a Nim+Nimpy Python lib for Linux/Windows/Mac ready for upload to Pythons PYPI.
- `nim4pypi` takes 1 full path of 1 Nim+Nimpy `*.nim` source code file and packages it for PYPI,
  creates `setup.py`, `setup.cfg`, helper scripts, ZIP Python Package, C files, H files, and more.
- This is a pure NimScript replacement of `python setup.py sdist`.
- Helper scripts to re-package, upload to PyPI, install locally for testing.

Example:

```nim
import nimpy
proc foo*(a, b: int): int {.exportpy.} = a + b
```

```
nim nim4pypi /full/path/to/file.nim
```

Then on `./dist/` folder the Python package is created, user can manually edit the files.
Result https://test.pypi.org/project/faster-than-csv/0.0.1/#files (just for demo)

:slightly_smiling_face:
